### PR TITLE
Validator fix

### DIFF
--- a/quest-editor/quest-editor-ejb/pom.xml
+++ b/quest-editor/quest-editor-ejb/pom.xml
@@ -47,6 +47,14 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/quest-editor/quest-editor-ejb/src/main/java/org/my/adventure/questeditor/ejb/beans/GraphEditorBean.java
+++ b/quest-editor/quest-editor-ejb/src/main/java/org/my/adventure/questeditor/ejb/beans/GraphEditorBean.java
@@ -7,6 +7,8 @@ import org.my.adventure.questeditor.ejb.builders.GraphBuilder;
 import org.my.adventure.questeditor.ejb.builders.QuestBuilder;
 import org.my.adventure.questeditor.ejb.builders.ViewBuilder;
 import org.my.adventure.questeditor.ejb.commands.*;
+import org.my.adventure.questeditor.ejb.graph.vaildator.ValidationStatus;
+import org.my.adventure.questeditor.ejb.graph.vaildator.Validator;
 import org.my.adventure.questeditor.ejb.views.NodeView;
 import org.my.adventure.questeditor.ejb.views.TransitionView;
 import org.primefaces.json.JSONArray;
@@ -138,6 +140,8 @@ public class GraphEditorBean implements Serializable {
         return transitionView;
     }
     public String save(JSONArray data) {
+        Validator validator = new Validator();
+        List<ValidationStatus> status = validator.validate(viewGraph);
         updatePositions(data);
         for(Command command : commandList)
             command.saveToDB(this);

--- a/quest-editor/quest-editor-ejb/src/main/java/org/my/adventure/questeditor/ejb/graph/vaildator/ValidationStatus.java
+++ b/quest-editor/quest-editor-ejb/src/main/java/org/my/adventure/questeditor/ejb/graph/vaildator/ValidationStatus.java
@@ -5,10 +5,8 @@ package org.my.adventure.questeditor.ejb.graph.vaildator;
  */
 public enum ValidationStatus {
     VALID,
-    NOT_VALID,
-    NOT_VALID_START_NODE,
-    NOT_VALID_END_NODE,
-    NOT_VALID_SATRT_AND_END_NODE,
-    NOT_VALID_CONNECTIVITY,
-    ERROR
+    MISSING_START_NODE,
+    MULTIPLE_START_NODES,
+    MISSING_END_NODE,
+    NOT_CONNECTED
 }

--- a/quest-editor/quest-editor-ejb/src/main/java/org/my/adventure/questeditor/ejb/graph/vaildator/Validator.java
+++ b/quest-editor/quest-editor-ejb/src/main/java/org/my/adventure/questeditor/ejb/graph/vaildator/Validator.java
@@ -1,11 +1,12 @@
 package org.my.adventure.questeditor.ejb.graph.vaildator;
 
 import org.jgrapht.Graph;
-import org.my.adventure.dao_manager.api.entities.Node;
 import org.my.adventure.questeditor.ejb.views.NodeView;
 import org.my.adventure.questeditor.ejb.views.TransitionView;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -13,61 +14,109 @@ import java.util.Set;
  */
 public class Validator {
 
-    public void marknode(NodeView node, Set<NodeView> nodes, Graph<NodeView, TransitionView> graph){
+    private void markNode(NodeView node, Set<NodeView> nodes, Graph<NodeView, TransitionView> graph){
         Set<TransitionView> transitions = graph.edgesOf(node);
         if (nodes.contains(node)){
             nodes.remove(node);
             for (TransitionView transition : transitions) {
                 if (transition.getFrom() == node && transition.getTo() != node)
-                    marknode(transition.getTo(), nodes, graph);
+                    markNode(transition.getTo(), nodes, graph);
             }
         }
     }
 
-    public ValidationStatus testConnectivity(Graph<NodeView, TransitionView> graph){
-        ValidationStatus result = ValidationStatus.NOT_VALID_CONNECTIVITY;
+    private ValidationStatus testConnectivity(Graph<NodeView, TransitionView> graph, NodeView startNode){
+        ValidationStatus result = ValidationStatus.NOT_CONNECTED;
         Set<NodeView> nodes = graph.vertexSet();
-        HashSet<NodeView> markSet = new HashSet<NodeView>();
-        for (NodeView node : nodes) {
-            markSet.add(node);
+        //if start node is null searching for first not end node;
+        if (nodes != null){
+            if (startNode == null){
+                do {
+                    startNode = nodes.iterator().next();
+                }while (isEnd(graph, startNode));
+            }
+            HashSet<NodeView> markSet = new HashSet<>();
+            for (NodeView node : nodes) {
+                markSet.add(node);
+            }
+            markNode(startNode, markSet, graph);
+            if (markSet.isEmpty())
+                result = ValidationStatus.VALID;
         }
-        marknode(nodes.iterator().next(), markSet, graph);
-        if (markSet.isEmpty())
-            result = ValidationStatus.VALID;
         return result;
     }
 
-    public ValidationStatus testStartEnd(Graph<NodeView, TransitionView> graph){
-        ValidationStatus result = ValidationStatus.NOT_VALID;
-        boolean endFinded = false;
-        boolean startFinded = false;
+    private List<NodeView> findStart(Graph<NodeView, TransitionView> graph){
+        List<NodeView> startNodes = new ArrayList<>();
+        NodeView start = null;
         Set<NodeView> nodes = graph.vertexSet();
+        nodeLoop:
         for (NodeView node : nodes) {
-            boolean endNode = true;
-            boolean startNode = true;
-            Set<TransitionView> transitionViews = graph.edgesOf(node);
-            for (TransitionView transitionView : transitionViews) {
-
-                if (!endFinded && transitionView.getFrom() == node){
-                    endNode = false;
-                }
-                if (!startFinded && transitionView.getTo() == node){
-                    startNode = false;
+            start = node;
+            Set<TransitionView> transitions = graph.edgesOf(node);
+            for (TransitionView transition : transitions) {
+                if (transition.getTo() == node){
+                    start = null;
+                    continue nodeLoop;
                 }
             }
-            if (endNode)
-                endFinded = true;
-            if (startNode)
-                startFinded = true;
-            if (startFinded && endFinded)
-                return ValidationStatus.VALID;
+            startNodes.add(start);
         }
-        if (startFinded && endFinded)
-            result = ValidationStatus.NOT_VALID_SATRT_AND_END_NODE;
-        else if (!startFinded)
-            result = ValidationStatus.NOT_VALID_START_NODE;
-        else if (!endFinded)
-            result = ValidationStatus.NOT_VALID_END_NODE;
+        return startNodes;
+    }
+
+    private ValidationStatus haveEnd(Graph<NodeView, TransitionView> graph){
+        Set<NodeView> nodes = graph.vertexSet();
+        nodeLoop:
+        for (NodeView node : nodes) {
+            Set<TransitionView> transitions = graph.edgesOf(node);
+            for (TransitionView transition : transitions) {
+                if (transition.getFrom() == node){
+                    continue nodeLoop;
+                }
+                return ValidationStatus.VALID;
+            }
+        }
+        return ValidationStatus.MISSING_END_NODE;
+    }
+
+    private boolean isEnd(Graph<NodeView, TransitionView> graph, NodeView node){
+        Set<TransitionView> transitions = graph.edgesOf(node);
+        for (TransitionView transition : transitions) {
+            if (transition.getFrom() == node)
+                return false;
+        }
+        return true;
+    }
+
+    public List<ValidationStatus> validation(Graph<NodeView, TransitionView> graph){
+        List<ValidationStatus> result = new ArrayList<>();
+
+        ValidationStatus endRes = haveEnd(graph);
+        if (endRes != ValidationStatus.VALID){
+            result.add(endRes);
+        }
+
+        List<NodeView> startNodes = findStart(graph);
+        NodeView startNode = null;
+        switch (startNodes.size()){
+            case 1: startNode = startNodes.get(0);
+                break;
+            case 0: result.add(ValidationStatus.MISSING_START_NODE);
+                break;
+            default: result.add(ValidationStatus.MULTIPLE_START_NODES);
+                break;
+        }
+
+        if (result.contains(ValidationStatus.MULTIPLE_START_NODES)){
+            result.add(ValidationStatus.NOT_CONNECTED);
+        }else {
+            ValidationStatus connRes = testConnectivity(graph, startNode);
+            if (connRes != ValidationStatus.VALID){
+                result.add(connRes);
+            }
+        }
+
         return result;
     }
 }

--- a/quest-editor/quest-editor-ejb/src/main/java/org/my/adventure/questeditor/ejb/graph/vaildator/Validator.java
+++ b/quest-editor/quest-editor-ejb/src/main/java/org/my/adventure/questeditor/ejb/graph/vaildator/Validator.java
@@ -89,7 +89,7 @@ public class Validator {
         return true;
     }
 
-    public List<ValidationStatus> validation(Graph<NodeView, TransitionView> graph){
+    public List<ValidationStatus> validate(Graph<NodeView, TransitionView> graph){
         List<ValidationStatus> result = new ArrayList<>();
 
         ValidationStatus endRes = haveEnd(graph);


### PR DESCRIPTION
Исправил поведение при нескольких стартовых узлах.
Поменял способ возвращения результата валидации:
Теперь в классе валидатора только один публичный метод (validate) и он возвращает список ошибок валидации, или пустой список, если ошибок нет.

Сделал всё отдельной веткой, что бы сразу можно было смёрджить.
